### PR TITLE
feat: enhance start and help commands

### DIFF
--- a/main.py
+++ b/main.py
@@ -61,7 +61,39 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     """Send a message when the command /help is issued."""
     user = update.effective_user
     logger.info(f"Help command received from user {user.full_name} (ID: {user.id})")
-    await update.message.reply_text("Help!")
+    
+    help_message = """📖 <b>Ayuda - Bot Floristería Morale's</b> 🌸
+
+    🔄 <b>Funcionalidades:</b>
+    • <b>Seguimiento de Ventas y Gastos:</b> Analiza automáticamente los mensajes para registrar ventas y gastos
+    • <b>Gestión de Transacciones:</b> Eliminar transacciones por ID
+    • <b>Reporte de Cierre Diario:</b> Genera un resumen de ventas diarias, gastos y balance de efectivo
+    • <b>Notificaciones en Vivo:</b> Envía notificaciones en tiempo real al propietario sobre las operaciones realizadas
+
+    📝 <b>Formatos para registrar transacciones:</b>
+
+    💰 <b>Para VENTAS:</b>
+    <code>1 ROSA TOTAL $1.00 MILA</code>
+    • Especificar: cantidad + producto + TOTAL + precio + nombre de la persona
+
+    💸 <b>Para GASTOS:</b>
+    <code>GASTE EN SOBRES TOTAL $18.00 JOSUE</code>
+    • Especificar: GASTE EN + descripción + TOTAL + precio + nombre de la persona
+
+    🗑️ <b>Para ELIMINAR transacciones:</b>
+    <code>ELIMINAR afb2cbb2-e041-4dae-a0d2-3d3db4dd146d MICHEL</code>
+    • Formato: ELIMINAR + ID de transacción + nombre de la persona
+
+    📊 <b>Para obtener CIERRE DIARIO:</b>
+    <code>CIERRE MARIA</code>
+    • Formato: cierre + nombre de la persona
+
+    🔔 <b>Notificaciones en Vivo:</b>
+    Las notificaciones automáticas al propietario están activas por defecto. Para desactivarlas, contacta al desarrollador.
+
+    💡 <b>Recuerda:</b> Siempre incluye tu nombre al final de cada comando para un mejor seguimiento."""
+    
+    await update.message.reply_html(help_message)
     logger.info(f"Help response sent to user {user.full_name}")
 
 

--- a/main.py
+++ b/main.py
@@ -36,8 +36,23 @@ async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Send a message when the command /start is issued."""
     user = update.effective_user
     logger.info(f"Start command received from user {user.full_name} (ID: {user.id})")
+    
+    welcome_message = f"""🌸 ¡Hola {user.mention_html()}! 🌸
+
+    Bienvenido/a al bot de ventas y gastos para la floristería Morale's �
+
+    📋 <b>¿Qué puedo hacer por ti?</b>
+    • Registrar ventas y transacciones
+    • Ayudarte con el control de gastos
+    • Mantener un registro de tus operaciones
+
+    💡 <b>Para comenzar:</b>
+    Simplemente envía un mensaje describiendo tu venta o gasto, y yo me encargaré del resto.
+
+    ❓ Si necesitas más ayuda, envía el comando /help"""
+    
     await update.message.reply_html(
-        rf"Hi {user.mention_html()}!",
+        welcome_message,
         reply_markup=ForceReply(selective=True),
     )
     logger.info(f"Start response sent to user {user.full_name}")


### PR DESCRIPTION
This pull request enhances the user experience for the `start` and `help` commands in the `main.py` file of the bot. The changes introduce detailed and user-friendly messages in Spanish to guide users on how to interact with the bot effectively.

### Enhancements to user experience:

* **Improved `/start` command response**:
  - Added a welcoming message in Spanish that introduces the bot's purpose and functionalities, including registering sales and expenses, helping with expense control, and maintaining operation records. The message also provides instructions on how to begin using the bot.

* **Enhanced `/help` command response**:
  - Replaced the generic "Help!" message with a comprehensive guide in Spanish detailing the bot's functionalities, formats for registering transactions (sales, expenses, deletions, and daily closure), and live notifications. The guide includes examples for clarity and emphasizes the importance of including the user's name in commands for better tracking.